### PR TITLE
chore: editor plugin registry entry

### DIFF
--- a/plugins/config-edit/package.json
+++ b/plugins/config-edit/package.json
@@ -7,6 +7,15 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/powersync-ja/powersync-cli"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "bugs": "https://github.com/powersync-ja/powersync-cli/issues",
   "files": [
     "dist",
     "editor-dist",


### PR DESCRIPTION
The Editor OCLIF plugin needs a registry entry in order for trusted publishing to work. Luckily this was picked up before any publishing was done. 