### PR TITLE
fix: missing docker compose template files

### DIFF
--- a/.changeset/tiny-bobcats-smile.md
+++ b/.changeset/tiny-bobcats-smile.md
@@ -1,0 +1,6 @@
+---
+'@powersync/cli-plugin-docker': patch
+'powersync': patch
+---
+
+Fixed missing docker-compose.yaml template files.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,67 @@
+# Functional Source License, Version 1.1, ALv2 Future License
+
+## Abbreviation
+
+FSL-1.1-ALv2
+
+## Notice
+
+Copyright 2026 Journey Mobile, Inc.
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under these Terms and Conditions, as indicated by our inclusion of these Terms and Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents, Redistribution and Trademark clauses below, we hereby grant you the right to use, copy, modify, create derivative works, publicly perform, publicly display and redistribute the Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A Permitted Purpose is any purpose other than a Competing Use. A Competing Use means making the Software available to others in a commercial product or service that:
+
+1. substitutes for the Software;
+2. substitutes for any other product or service we offer using the Software that exists as of the date we make the Software available; or
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+2. for non-commercial education;
+3. for non-commercial research; and
+4. in connection with professional services that you provide to a licensee using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our patents, the license grant above includes a license under our patents. If you make a claim against any party that the Software infringes or contributes to the infringement of any patent, then your patent license to the Software ends immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives of the Software.
+If you redistribute any copies, modifications or derivatives of the Software, you must include a copy of or a link to these Terms and Conditions and not remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO THE SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES, EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of the Software, you have no right under these Terms and Conditions to use our trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software under the Apache License, Version 2.0 that is effective on the second anniversary of the date we make the Software available. On or after that date, you may use the Software under the Apache License, Version 2.0, in which case the following will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.

--- a/cli/README.md
+++ b/cli/README.md
@@ -720,6 +720,8 @@ EXAMPLES
   $ powersync edit config --directory ./powersync
 ```
 
+_See code: [@powersync/cli-plugin-config-edit](https://github.com/powersync-ja/powersync-cli/blob/v0.9.0/src/commands/edit/config.ts)_
+
 ## `powersync fetch config`
 
 [Cloud only] Print linked Cloud instance config (YAML or JSON).

--- a/plugins/docker/package.json
+++ b/plugins/docker/package.json
@@ -22,6 +22,7 @@
   },
   "bugs": "https://github.com/powersync-ja/powersync-cli/issues",
   "scripts": {
+    "build": "tsc -b && node scripts/copy-template-resources.mjs",
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "lint": "eslint .",
     "prepack": "oclif manifest"


### PR DESCRIPTION
closes https://github.com/powersync-ja/powersync-cli/issues/19

Users have reported the following error when running `powersync docker configure`

```
    Error: ENOENT: no such file or directory, open '/home/lcmch/.npm/_npx/0be151bc818c02b
    f/node_modules/@powersync/cli-plugin-docker/dist/templates/main-compose.yaml'
    Code: ENOENT
```

The docker plugin package has a script which should copy template files to the `dist` folder.

It seems like the `@powersync/cli-plugin-docker` package's `build` script was somehow deleted - perhaps due to a merge conflict resolution. 

This re-adds the script which resolves the issue. Tested by doing a clean build then using `docker` commands.

A dev release was also tested.

```
❯ npx powersync@0.0.0-dev-20260305082615 docker configure
✔ Select a database module for a replication source. Use external to configure an existing database. postgres
✔ Select a storage module for PowerSync bucket metadata. Use external to configure an existing database. postgres
Note: the Postgres database template is incomplete.
Update docker/modules/database-postgres/init-scripts/ with your schema (tables and publication) before deploying.
Init scripts run only when the DB volume is empty. If you see "Publication powersync does not exist", run: powersync docker stop --remove --remove-volumes then powersync docker reset again.

Configured /Users/stevenontong/Documents/platform_code/powersync/new-cli/playground/powersync/docker
  - docker-compose.yaml (includes modules, adds PowerSync service)
  - .env
  - Merged config into service.yaml
  - cli.yaml (plugins.docker.project_name: powersync_playground)

Next: run "powersync docker start" to start the stack.
```

Side addition: this adds a LICENSE file to the repo root. 