### PR TITLE
Migrate command: Use `@powersync/sync-config-tools` package

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -16,7 +16,7 @@
     "@oclif/plugin-commands": "^4.1.40",
     "@oclif/plugin-help": "^6",
     "@oclif/plugin-plugins": "^5",
-    "@powersync-community/sync-config-rewriter": "^0.1.4",
+    "@powersync/sync-config-tools": "^0.1.1",
     "@powersync/cli-core": "workspace:*",
     "@powersync/cli-plugin-config-edit": "workspace:*",
     "@powersync/cli-plugin-docker": "workspace:*",

--- a/cli/src/commands/migrate/sync-rules.ts
+++ b/cli/src/commands/migrate/sync-rules.ts
@@ -1,6 +1,6 @@
 import { Flags, ux } from '@oclif/core';
-import { instantiate } from '@powersync-community/sync-config-rewriter';
 import { SharedInstanceCommand, SYNC_FILENAME, YAML_SYNC_RULES_SCHEMA } from '@powersync/cli-core';
+import { instantiate } from '@powersync/sync-config-tools';
 import { access, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -37,9 +37,7 @@ export default class MigrateSyncRules extends SharedInstanceCommand {
 
     const syncInputContent = await readFile(syncInputPath, 'utf8');
 
-    const wasmBuffer = await readFile(
-      fileURLToPath(import.meta.resolve('@powersync-community/sync-config-rewriter/compiled.wasm'))
-    );
+    const wasmBuffer = await readFile(fileURLToPath(import.meta.resolve('@powersync/sync-config-tools/compiled.wasm')));
 
     const SyncStreamsRewriter = await instantiate(wasmBuffer);
 

--- a/cli/test/commands/migrate.test.ts
+++ b/cli/test/commands/migrate.test.ts
@@ -1,0 +1,44 @@
+import { runCommand } from '@oclif/test';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { expect, onTestFinished, test } from 'vitest';
+
+import { root } from '../helpers/root.js';
+
+test('migrates from sync rules to sync streams', async () => {
+  const testDirectory = mkdtempSync(join(tmpdir(), 'migrate-test-'));
+  onTestFinished(() => rmSync(testDirectory, { recursive: true }));
+
+  const inputFile = join(testDirectory, 'input.yaml');
+  const outputFile = join(testDirectory, 'output.yaml');
+  writeFileSync(
+    inputFile,
+    `
+bucket_definitions:
+  user_lists:
+    parameters: SELECT request.user_id() as user_id 
+    data:
+      - SELECT * FROM lists WHERE owner_id = bucket.user_id   
+`
+  );
+
+  const result = await runCommand(`migrate sync-rules --input-file ${inputFile} --output-file ${outputFile}`, { root });
+  expect(result.error).toBeUndefined();
+
+  const transformed = readFileSync(outputFile).toString('utf-8');
+  expect(transformed)
+    .toStrictEqual(`# Adds YAML Schema support for VSCode users with the YAML extension installed. This enables features like validation and autocompletion based on the provided schema.
+# yaml-language-server: $schema=https://unpkg.com/@powersync/service-sync-rules@latest/schema/sync_rules.json
+config:
+  edition: 3
+streams:
+  # This Sync Stream has been translated from bucket definitions. There may be more efficient ways to express these queries.
+  # You can add additional queries to this list if you need them.
+  # For details, see the documentation: https://docs.powersync.com/sync/streams/overview
+  migrated_to_streams:
+    auto_subscribe: true
+    queries:
+      - SELECT * FROM lists WHERE owner_id = auth.user_id()
+`);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,9 +88,6 @@ importers:
       '@oclif/plugin-plugins':
         specifier: ^5
         version: 5.4.55
-      '@powersync-community/sync-config-rewriter':
-        specifier: ^0.1.4
-        version: 0.1.4
       '@powersync/cli-core':
         specifier: workspace:*
         version: link:../packages/cli-core
@@ -115,6 +112,9 @@ importers:
       '@powersync/service-types':
         specifier: 'catalog:'
         version: 0.15.0
+      '@powersync/sync-config-tools':
+        specifier: ^0.1.1
+        version: 0.1.1
       bson:
         specifier: ^7.2.0
         version: 7.2.0
@@ -1605,9 +1605,6 @@ packages:
     resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
     engines: {node: '>=12'}
 
-  '@powersync-community/sync-config-rewriter@0.1.4':
-    resolution: {integrity: sha512-xJez2HuLg7XIdy6D5BMe1OyzAML7I80eBaYzHEsZlsmoAyp5xpoouWXFlnquQYM662phv+eYm3TtOuGXHk6ewQ==}
-
   '@powersync/management-client@0.0.6':
     resolution: {integrity: sha512-s5tvk/3JUw9B1ry0X8YH30sMscqf5xkbGK0XNSZ4X6o0ATtJWxxe97Fgg1HoNTfN2W7lMSyTyZnBdf9jsVOluQ==}
 
@@ -1628,6 +1625,9 @@ packages:
 
   '@powersync/service-types@0.15.0':
     resolution: {integrity: sha512-wIdHCT+vhwoJAMZ414/dwG8fd51+fEWnPbwShkwNE5XTwA0UGOT8aGyVZqzT8PT0sVos5famYYqG203Mjb7q6g==}
+
+  '@powersync/sync-config-tools@0.1.1':
+    resolution: {integrity: sha512-+lSmE6uGDUmUFc+XnYIatp746LMMLCw0DK+VyWnheuk4LRxENSqaZwLYySekWTDg9fBsXQJakAQ6sHHVMSTsbg==}
 
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
@@ -8960,8 +8960,6 @@ snapshots:
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
 
-  '@powersync-community/sync-config-rewriter@0.1.4': {}
-
   '@powersync/management-client@0.0.6(@types/debug@4.1.12)(@types/json-schema@7.0.15)(jiti@2.6.1)(jsdom@27.4.0)(tsx@4.21.0)(yaml@2.8.2)':
     dependencies:
       '@journeyapps-labs/common-sdk': 1.0.3(@types/debug@4.1.12)(@types/json-schema@7.0.15)(jiti@2.6.1)(jsdom@27.4.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -9071,6 +9069,8 @@ snapshots:
       uri-js: 4.4.1
     transitivePeerDependencies:
       - babel-plugin-macros
+
+  '@powersync/sync-config-tools@0.1.1': {}
 
   '@radix-ui/primitive@1.1.3': {}
 


### PR DESCRIPTION
This replaces `@powersync-community/sync-config-rewriter` with `@powersync/sync-config-tools`. I've also added a small test for that command.

Skipping a changesets entry since we already have one for the earlier upgrade.