### PR TITLE
chore: fix release builds

### DIFF
--- a/.github/workflows/buildArtifacts.yml
+++ b/.github/workflows/buildArtifacts.yml
@@ -1,5 +1,9 @@
 name: Build CLI Installer Artifacts Partial
 
+env:
+  # Increase heap to keep Nitro/Vite SSR builds (editor) from OOMing while treeshaking.
+  NODE_OPTIONS: --max-old-space-size=4096
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/onDispatchBuildArtifacts.yml
+++ b/.github/workflows/onDispatchBuildArtifacts.yml
@@ -12,4 +12,4 @@ jobs:
   build-artifacts:
     uses: ./.github/workflows/buildArtifacts.yml
     with:
-      retention-days: ${{ inputs.retention-days || 7 }}
+      retention-days: ${{ inputs.retention-days }}


### PR DESCRIPTION
The `editor` package's `build` script failed due to OOM when building [here](https://github.com/powersync-ja/powersync-cli/actions/runs/26503930095/job/78051653344). 

The OOM is due to treeshaking used to minimize the web bundle.

We typically supply a `max-old-size` parameter to other actions - which prevents this warning. This add the `max-old-size` param to the partial action, which should apply to all jobs in the workflow matrix.

Removing the default coersion for `retention-days` should also fix manual invocations for test builds. This value already has a default specified in the input delcaration.