### PR TITLE
fix: absolute path resolution for directory flag (fixes #55)

### DIFF
--- a/.changeset/fix-directory-path.md
+++ b/.changeset/fix-directory-path.md
@@ -1,0 +1,6 @@
+---
+'@powersync/cli-core': patch
+'powersync': patch
+---
+
+fix `--directory` absolute path resolution in CLI

--- a/cli/src/commands/pull/instance.ts
+++ b/cli/src/commands/pull/instance.ts
@@ -112,7 +112,7 @@ export default class PullInstance extends CloudInstanceCommand {
         orgId: resolvedLink.org_id,
         projectId: resolvedLink.project_id
       });
-      this.log(`Created ${ux.colorize('blue', `${directory}/${CLI_FILENAME}`)} with Cloud instance link.`);
+      this.log(`Created ${ux.colorize('blue', join(projectDir, CLI_FILENAME))} with Cloud instance link.`);
     }
 
     const { linked } = await this.loadProject(flags);

--- a/packages/cli-core/src/command-types/PowerSyncCommand.ts
+++ b/packages/cli-core/src/command-types/PowerSyncCommand.ts
@@ -1,6 +1,6 @@
 import { JourneyError } from '@journeyapps-labs/micro-errors';
 import { Command, ux } from '@oclif/core';
-import { join } from 'node:path';
+import { resolve } from 'node:path';
 
 import {
   formatPowersyncServiceErrorDisplay,
@@ -26,7 +26,7 @@ export abstract class PowerSyncCommand extends Command {
 
   /** Resolves the project directory path from the --directory flag (relative to cwd). */
   resolveProjectDir(flags: { directory: string }): string {
-    return join(process.cwd(), flags.directory);
+    return resolve(process.cwd(), flags.directory);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes an issue where providing an absolute path to the `--directory` flag incorrectly appended the absolute path to the current working directory.

## Changes

- `src/utils.ts`: updated `resolveProjectDir` to use `path.resolve` for proper absolute path resolution
- `src/commands/pull/instance.ts`: updated the log message to print the actual `projectDir` instead of the raw flag value

## Testing

- Local execution confirms that `--directory /absolute/path` resolves correctly
- Existing unit tests pass successfully

Closes #55
