### PR TITLE
Fix CI builds

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -119,11 +119,10 @@
   },
   "scripts": {
     "dev": "tsx bin/dev.js",
-    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo oclif.manifest.json",
     "build": "tsc -b",
     "lint": "eslint",
-    "postpack": "rm oclif.manifest.json",
-    "pretest": "pnpm run build",
+    "pretest": "rm -f oclif.manifest.json && pnpm run build",
     "readme:generate": "oclif readme && pnpm exec prettier --write README.md",
     "prepack": "oclif manifest && pnpm run readme:generate",
     "test": "vitest",


### PR DESCRIPTION
pnpm v10 forked out to npm to handle packaging, which roughly performed `prepack` -> `list files` -> `generate tarball` -> `postpack`. pnpm v11 reimplements this system, but now it performs `prepack` -> `list files` -> `postpack` -> `generate tarball`. This broke builds because pnpm sees the file `oclif.manifest.json`, but `postpack` deletes `oclif.manifest.json` before pnpm can bundle it into the tarball, so it fails with an ENOENT not found error.

This fixes that by removing the `postpack` command and instead making `clean` and `pretest` delete the `oclif.manifest.json` file instead (so as to not hinder local development). I'm not sure why we were deleting `oclif.manifest.json` in postpack; happy to modify if it needs to be there for some purpose.